### PR TITLE
Fix compile errors. Bump "flume-ng-core" version. Add configuration example for MySQL to "README.md".

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ flume-ng-sql-sink(Under development)
 
 This project is used for [flume-ng](https://github.com/apache/flume) to communicate with sql databases
 
+Tested working with:
+  - Java 11
+  - Flume 1.11.0
+
 Current sql database engines supported
 -------------------------------
 - After the last update the code has been integrated with hibernate, so all databases supported by this technology should work.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,89 @@ Mandatory properties in <b>bold</b>
 | hibernate.c3p0.max_size | - | Max connection pool size |
 | default.charset.resultset | UTF-8 | Result set from DB converted to charset character encoding |
 
-Configuration example
+Configuration example for MySQL
+--------------------
+Create a MySQL database to store the sink data. In a MySQL client, run as root:
+```
+CREATE DATABASE flume DEFAULT CHARSET utf8mb4;
+```
+
+Create a MySQL table to store the sink data. In a MySQL client, run as root:
+```
+CREATE TABLE flume.log (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Log ID',
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+  msg VARCHAR(10000) NOT NULL COMMENT 'Log message',
+  PRIMARY KEY (id),
+  KEY create_time (create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+Create a MySQL user. In a MySQL client, run as root:
+```
+CREATE USER flume_user@`%` IDENTIFIED BY 'flume_user_password';
+
+GRANT INSERT ON flume.log TO flume_user@`%`;
+```
+
+Create a flume config file **flume.config**:
+```
+# +++++
+agent.channels=chan1
+
+agent.channels.chan1.type=memory
+
+
+# +++++
+agent.sources=src1
+
+agent.sources.src1.channels=chan1
+
+agent.sources.src1.type=exec
+
+agent.sources.src1.command=tail -F /tmp/flume_source.log
+
+
+# +++++
+agent.sinks=sink1
+
+agent.sinks.sink1.channel=chan1
+
+agent.sinks.sink1.type=org.ricco.flume.sink.SQLSink
+
+agent.sinks.sink1.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# MySQL host, port, and database name. 
+agent.sinks.sink1.hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/flume?useUnicode=true&characterEncoding=utf-8
+
+# MySQL username.
+agent.sinks.sink1.hibernate.connection.user=flume_user
+
+# MySQL password.
+agent.sinks.sink1.hibernate.connection.password=flume_user_password
+
+agent.sinks.sink1.hibernate.connection.autocommit=true
+
+# MySQL table name of the table to store the sink data.
+agent.sinks.sink1.table.prefix=log
+
+# MySQL table column name of the column to store the sink data.
+agent.sinks.sink1.columns.to.insert=msg
+```
+
+Run flume:
+```
+flume-ng agent -name agent -conf-file flume.config
+```
+
+Append text to the input file of the flume source:
+```
+echo test >> /tmp/flume_source.log
+```
+
+Check the data inserted into the database table of the flume sink. If there is no data inserted, check the **flume-ng** command's log file for any error messages.
+
+Configuration example for DB2
 --------------------
 
 ```properties

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,11 @@
     <artifactId>flume-ng-sql-sink</artifactId>
     <version>1.0.0</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <packaging>jar</packaging>
     <name>Flume SQL Sink</name>
     <description>This project is used for flume-ng to export data to SQL databases.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.flume</groupId>
             <artifactId>flume-ng-core</artifactId>
-            <version>1.8.0</version>
+            <version>1.11.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/org/ricco/flume/sink/SQLSinkHelper.java
+++ b/src/main/java/org/ricco/flume/sink/SQLSinkHelper.java
@@ -12,15 +12,15 @@ import org.slf4j.LoggerFactory;
  * Helper to manage configuration parameters and utility methods <p>
  * <p>
  * Configuration parameters readed from flume configuration file:
- * <tt>type: </tt> org.keedio.flume.source.SQLSink <p>
- * <tt>tablePrefix: </tt> tablePrefix to read from <p>
- * <tt>columns.to.select: </tt> columns to select for import data (* will import all) <p>
- * <tt>run.query.delay: </tt> delay time to execute each query to database <p>
- * <tt>status.file.path: </tt> Directory to save status file <p>
- * <tt>status.file.name: </tt> Name for status file (saves last row index processed) <p>
- * <tt>batch.size: </tt> Batch size to send events from flume source to flume channel <p>
- * <tt>max.rows: </tt> Max rows to import from DB in one query <p>
- * <tt>custom.query: </tt> Custom query to execute to database (be careful) <p>
+ * <code>type: </code> org.keedio.flume.source.SQLSink <p>
+ * <code>tablePrefix: </code> tablePrefix to read from <p>
+ * <code>columns.to.select: </code> columns to select for import data (* will import all) <p>
+ * <code>run.query.delay: </code> delay time to execute each query to database <p>
+ * <code>status.file.path: </code> Directory to save status file <p>
+ * <code>status.file.name: </code> Name for status file (saves last row index processed) <p>
+ * <code>batch.size: </code> Batch size to send events from flume source to flume channel <p>
+ * <code>max.rows: </code> Max rows to import from DB in one query <p>
+ * <code>custom.query: </code> Custom query to execute to database (be careful) <p>
  *
  * @author <a href="mailto:ricco@qq.com">Ricco</a>
  */


### PR DESCRIPTION
Fix javadoc error "HibernateHelper.java:159: error: unmappable character (0x80) for encoding GBK".

Fix javadoc warning "The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module".

Fix javadoc error "tag not supported in the generated HTML version: tt".

Bump "flume-ng-core" version to 1.11.0.

Add the "Configuration example for MySQL" section to "README.md".

Add the "Tested working with" section to "README.md".